### PR TITLE
Fix typo 'abandonned'

### DIFF
--- a/doc/HistData/Langren.all.html
+++ b/doc/HistData/Langren.all.html
@@ -203,7 +203,7 @@ if (require(ReadImages)) {
 
 ## End(Not run)
 
-### First attempt using ggplot2; temporarily abandonned.
+### First attempt using ggplot2; temporarily abandoned.
 ## Not run: 
 require(maps)
 require(ggplot2)

--- a/doc/HistData/Langren1644.html
+++ b/doc/HistData/Langren1644.html
@@ -203,7 +203,7 @@ if (require(ReadImages)) {
 
 ## End(Not run)
 
-### First attempt using ggplot2; temporarily abandonned.
+### First attempt using ggplot2; temporarily abandoned.
 ## Not run: 
 require(maps)
 require(ggplot2)

--- a/doc/HistData/rst/Langren.all.rst
+++ b/doc/HistData/rst/Langren.all.rst
@@ -212,7 +212,7 @@ Examples
 
     ## End(Not run)
 
-    ### First attempt using ggplot2; temporarily abandonned.
+    ### First attempt using ggplot2; temporarily abandoned.
     ## Not run: 
     require(maps)
     require(ggplot2)

--- a/doc/HistData/rst/Langren1644.rst
+++ b/doc/HistData/rst/Langren1644.rst
@@ -212,7 +212,7 @@ Examples
 
     ## End(Not run)
 
-    ### First attempt using ggplot2; temporarily abandonned.
+    ### First attempt using ggplot2; temporarily abandoned.
     ## Not run: 
     require(maps)
     require(ggplot2)


### PR DESCRIPTION
Hi! I'm a bot that checks GitHub for spelling mistakes, and I found one in your repository. When it
should be 'abandoned', you typed 'abandonned'. I created this pull request to fix it!

If you think there is anything wrong with this pull request or just have a question, be kind to mail me 
at thetypomaster@hotmail.com (professional email, huh?). I’ll try to address the problem as soon as
I’m aware of it.

Looking for the source code of this bot? Well, you have to be patient! The bot is under development
and I will publish the source code as soon as I’m finished with it.

If you decide to close this pull request, pleace specify why before doing so.

With kind regards,
TheTypoMaster
